### PR TITLE
Add FuseSoC support

### DIFF
--- a/sha512.core
+++ b/sha512.core
@@ -1,0 +1,50 @@
+CAPI=2:
+name : ::sha512:0
+
+filesets:
+  rtl:
+    files:
+      - src/rtl/sha512_k_constants.v
+      - src/rtl/sha512.v
+      - src/rtl/sha512_w_mem.v
+      - src/rtl/sha512_core.v
+      - src/rtl/sha512_h_constants.v
+    file_type : verilogSource
+  tb_sha512:
+    files:
+      - src/tb/tb_sha512.v
+    file_type : verilogSource
+  tb_sha512_core:
+    files:
+      - src/tb/tb_sha512_core.v
+    file_type : verilogSource
+
+targets:
+  default:
+    filesets : [rtl]
+
+  tb_sha512:
+    default_tool : icarus
+    filesets     : [rtl, tb_sha512]
+    parameters   : [DEBUG]
+    toplevel     : [tb_sha512]
+
+  tb_sha512_core:
+    default_tool : icarus
+    filesets     : [rtl, tb_sha512_core]
+    parameters   : [DEBUG]
+    toplevel     : [tb_sha512_core]
+
+  lint:
+    default_tool : verilator
+    filesets : [rtl]
+    tools:
+      verilator:
+        mode : lint-only
+    toplevel : [sha512]
+
+parameters:
+  DEBUG:
+    datatype    : bool
+    description : Enable debug printouts
+    paramtype   : vlogparam


### PR DESCRIPTION
This adds FuseSoC support for linting, building and running the top and core testbenches.

The FuseSoC support can be tested by first creating a workspace directory and register the libraries by running `fusesoc library add sha512 https://github.com/secworks/sha512` or, alternatively if the repo is already on disk and you want to use that instead, run `fusesoc library add sha512 /path/to/repo`

To list all targets, run `fusesoc core-info sha512`.

To run a simulation use `fusesoc run --target=<target> --tool=<tool> sha512`, where `<tool>` is any of the FuseSoC-supported RTL simulators (tested with icarus, isim, modelsim and xsim). If --tool is left out from the simulation, FuseSoC will use icarus as the default tool. Debug printouts can be added by adding `--DEBUG` at the end of the argument list.

To run verilator as a linter for the code, run `fusesoc run --target=lint sha512`
